### PR TITLE
Modified MaterialContainer, worldFoctory, and block to allow dynamic

### DIFF
--- a/common/materialContainer/MaterialContainer.cpp
+++ b/common/materialContainer/MaterialContainer.cpp
@@ -10,7 +10,7 @@
 
 Biosphere Biosphere::getBasicBiosphere()
 {
-  std::vector<Biome> vec;
+  std::vector<std::shared_ptr<Biome>> vec;
   vec.push_back(Biome::sandyDesert());
   vec.push_back(Biome::mountain());
   vec.push_back(Biome::fertileFarmland());
@@ -19,103 +19,96 @@ Biosphere Biosphere::getBasicBiosphere()
   return bs;
 }
 
-Biome Biome::sandyDesert()
+std::shared_ptr<Biome> Biome::sandyDesert()
 {
-  std::vector<Ground> vec;
-  vec.push_back(Ground::noOre());
-  vec.push_back(Ground::sand());
-  vec.push_back(Ground::oasis());
+  std::vector<std::shared_ptr<GroundContainer>> vec;
+  vec.push_back(GroundContainer::noOre());
+  vec.push_back(GroundContainer::sand());
+  vec.push_back(GroundContainer::oasis());
 
   std::string name = "sandyDesert";
-  Biome bi(name, vec, .33, 10.0);
-  return bi;
+  return std::make_shared<Biome>(name, vec, .33, 10.0);
 }
 
-Biome Biome::mountain()
+std::shared_ptr<Biome> Biome::mountain()
 {
-  std::vector<Ground> vec;
-  vec.push_back(Ground::noOre());
-  vec.push_back(Ground::diamondDeposits());
-  vec.push_back(Ground::goldDeposits());
-  vec.push_back(Ground::ironDeposits());
+  std::vector<std::shared_ptr<GroundContainer>> vec;
+  vec.push_back(GroundContainer::noOre());
+  vec.push_back(GroundContainer::diamondDeposits());
+  vec.push_back(GroundContainer::goldDeposits());
+  vec.push_back(GroundContainer::ironDeposits());
 
   std::string name = "Mountain";
-  Biome bi(name, vec, .33, 10.0);
-  return bi;
+  return std::make_shared<Biome>(name, vec, .33, 10.0);
 }
 
-Biome Biome::fertileFarmland()
+std::shared_ptr<Biome> Biome::fertileFarmland()
 {
-  std::vector<Ground> vec;
-  vec.push_back(Ground::soil());
-  vec.push_back(Ground::rockySoil());
-  vec.push_back(Ground::sandySoil());
+  std::vector<std::shared_ptr<GroundContainer>> vec;
+  vec.push_back(GroundContainer::soil());
+  vec.push_back(GroundContainer::rockySoil());
+  vec.push_back(GroundContainer::sandySoil());
 
   std::string name = "fertileFarmland";
-  Biome bi(name, vec, .33, 10.0);
-  return bi;
+  return std::make_shared<Biome>(name, vec, .33, 10.0);
 }
 
-Ground Ground::sand()
+std::shared_ptr<GroundContainer> GroundContainer::sand()
 {
-  std::vector<Material> vec;
+  std::vector<std::shared_ptr<Material>> vec;
   vec.push_back(Material::Sand());
 
   std::string name = "sand";
-  Ground g(name, vec, .3, 5.0);
-  return g;
+  return std::make_shared<GroundContainer>(name, vec, .3, 5.0);
+
 }
 
-Ground Ground::oasis()
+std::shared_ptr<GroundContainer> GroundContainer::oasis()
 {
-  std::vector<Material> vec;
+  std::vector<std::shared_ptr<Material>> vec;
   vec.push_back(Material::Sand());
 
   vec.push_back(Material::Soil());
 
   std::string name = "oasis";
-  Ground g(name, vec, .05, 5.0);
-  return g;
+  return std::make_shared<GroundContainer>(name, vec, .05, 5.0);
 }
 
-Ground Ground::ironDeposits()
+std::shared_ptr<GroundContainer> GroundContainer::ironDeposits()
 {
-  std::vector<Material> vec;
+  std::vector<std::shared_ptr<Material>> vec;
   vec.push_back(Material::Stone());
   vec.push_back(Material::Iron());
 
   std::string name = "ironDeposits";
-  Ground g(name, vec, .2, 5.0);
-  return g;
+  return std::make_shared<GroundContainer>(name, vec, .2, 5.0);
 }
 
-Ground Ground::goldDeposits()
+std::shared_ptr<GroundContainer> GroundContainer::goldDeposits()
 {
-  std::vector<Material> vec;
+  std::vector<std::shared_ptr<Material>> vec;
   vec.push_back(Material::Stone());
   vec.push_back(Material::Gold());
   vec.push_back(Material::Iron());
 
   std::string name = "goldDeposits";
-  Ground g(name, vec, .1, 5.0);
-  return g;
+  return std::make_shared<GroundContainer>(name, vec, .1, 5.0);
 }
 
-Ground Ground::diamondDeposits()
+std::shared_ptr<GroundContainer> GroundContainer::diamondDeposits()
 {
-  std::vector<Material> vec;
+  std::vector<std::shared_ptr<Material>> vec;
   vec.push_back(Material::Stone());
   vec.push_back(Material::Diamond());
   vec.push_back(Material::Coal());
 
   std::string name = "diamondDeposits";
-  Ground g(name, vec, .03, 5.0);
-  return g;
+  return std::make_shared<GroundContainer>(name, vec, .03, 5.0);
 }
 
-Ground Ground::noOre()
+std::shared_ptr<GroundContainer> GroundContainer::noOre()
 {
-  std::vector<Material> vec;
+  std::vector<std::shared_ptr<Material>> vec;
   vec.push_back(Material::Stone());
   vec.push_back(Material::Soil());
   vec.push_back(Material::Coal());
@@ -123,83 +116,153 @@ Ground Ground::noOre()
   vec.push_back(Material::Sand());
 
   std::string name = "noOre";
-  Ground g(name, vec, .5, 10.0);
-  return g;
+  return std::make_shared<GroundContainer>(name, vec, .5, 10.0);
 }
 
-Ground Ground::soil()
+std::shared_ptr<GroundContainer> GroundContainer::soil()
 {
-  std::vector<Material> vec;
+  std::vector<std::shared_ptr<Material>> vec;
   vec.push_back(Material::Soil());
 
   std::string name = "soil";
-  Ground g(name, vec, .5, 10.0);
-  return g;
+  return std::make_shared<GroundContainer>(name, vec, .5, 10.0);
 }
 
-Ground Ground::rockySoil()
+std::shared_ptr<GroundContainer> GroundContainer::rockySoil()
 {
-  std::vector<Material> vec;
+  std::vector<std::shared_ptr<Material>> vec;
   vec.push_back(Material::Stone());
   vec.push_back(Material::Soil());
   vec.push_back(Material::Gravel());
 
   std::string name = "rockySoil";
-  Ground g(name, vec, .2, 10.0);
-  return g;
+  return std::make_shared<GroundContainer>(name, vec, .2, 10.0);
 }
 
-Ground Ground::sandySoil()
+std::shared_ptr<GroundContainer> GroundContainer::sandySoil()
 {
-  std::vector<Material> vec;
+  std::vector<std::shared_ptr<Material>> vec;
   vec.push_back(Material::Sand());
   vec.push_back(Material::Soil());
 
   std::string name = "sandySoil";
-  Ground g(name, vec, .2, 10.0);
-  return g;
+  return std::make_shared<GroundContainer>(name, vec, .2, 10.0);
 }
 
-Material Ground::getMaterial()
+std::shared_ptr<Material> GroundContainer::getMaterial(int x, int y, int z)
 {
-  double noise = PerlinNoise();
+  double noise = PN(x, y, z);
   return getElement(noise);
 }
 
-Material Material::Coal()
-{
-  return Material("Coal", .2);
-}
-Material Material::Iron()
-{
-  return Material("Iron", .1);
-}
-Material Material::Soil()
-{
-  return Material("Soil", 1.0);
-}
-Material Material::Gravel()
-{
-  return Material("Gravel", .2);
-}
-Material Material::Sand()
-{
-  return Material("Sand", .7);
-}
-Material Material::Diamond()
-{
-  return Material("Diamond", .05);
-}
-Material Material::Stone()
-{
-  return Material("Stone", .6);
-}
-Material Material::Gold()
-{
-  return Material("Gold", .1);
+std::shared_ptr<Material> Material::makenew(std::string name, BlockType type, double freq){
+  materialMap.insert(std::pair<std::string,std::shared_ptr<Material>>(name,std::make_shared<Material>(name,type,freq)));
+  return materialMap[name];
 }
 
-Material Material::getMaterial()
+std::shared_ptr<Material> Material::getFromType(BlockType BT)
 {
-  return Material(*this);
+  switch(BT)
+  {
+    case BlockType::Coal:
+       return Material::Coal(); 
+     
+     case BlockType::Iron:
+       return Material::Iron(); 
+
+     case BlockType::Ground:
+       return Material::Soil(); 
+
+     case BlockType::Gravel:
+       return Material::Gravel(); 
+
+     case BlockType::Sand:
+       return Material::Sand(); 
+
+     case BlockType::Diamond:
+       return Material::Diamond(); 
+
+     case BlockType::Stone:
+       return Material::Stone(); 
+
+     case BlockType::Gold:
+       return Material::Gold();
+
+     default:
+       return Material::Default(); 
+  }
 }
+
+
+std::shared_ptr<Material> Material::Default()
+{
+  if(materialMap.count("None")>0)
+    return materialMap["None"]; 
+
+  return Material::makenew("None", BlockType::Inactive, .2);
+}
+std::shared_ptr<Material> Material::Coal()
+{
+  if(materialMap.count("Coal")>0)
+    return materialMap["Coal"]; 
+  return Material::makenew("Coal", BlockType::Coal, .2);
+}
+std::shared_ptr<Material> Material::Iron()
+{
+  if(materialMap.count("Iron")>0)
+    return materialMap["Iron"]; 
+  return Material::makenew("Iron", BlockType::Iron, .1);
+}
+std::shared_ptr<Material> Material::Soil()
+{
+  if(materialMap.count("Soil")>0)
+    return materialMap["Soil"]; 
+  return Material::makenew("Soil", BlockType::Ground, 1.0);
+}
+std::shared_ptr<Material> Material::Gravel()
+{
+  if(materialMap.count("Gravel")>0)
+    return materialMap["Gravel"]; 
+  return Material::makenew("Gravel", BlockType::Gravel, .2);
+}
+std::shared_ptr<Material> Material::Sand()
+{
+  if(materialMap.count("Sand")>0)
+    return materialMap["Sand"]; 
+  return Material::makenew("Sand", BlockType::Sand, .7);
+}
+std::shared_ptr<Material> Material::Diamond()
+{
+  if(materialMap.count("Diamond")>0)
+    return materialMap["Diamond"]; 
+  return Material::makenew("Diamond", BlockType::Diamond, .05);
+}
+std::shared_ptr<Material> Material::Stone()
+{
+  if(materialMap.count("Stone")>0)
+    return materialMap["Stone"]; 
+  return Material::makenew("Stone", BlockType::Stone, .6);
+}
+std::shared_ptr<Material> Material::Gold()
+{
+  if(materialMap.count("Gold")>0)
+    return materialMap["Gold"]; 
+  return Material::makenew("Gold", BlockType::Gold, .1);
+}
+
+std::shared_ptr<Material> Material::getMaterial(int x, int y, int z)
+{
+  (void) x;
+  (void) y;
+  (void) z;
+  return Default();
+}
+
+const double GROUND_OFFSET=2e5;
+const double GROUND_SMOOTHNESS=2;
+
+const double BIOME_OFFSET=1e5;
+const double BIOME_SMOOTHNESS=1e-1;
+
+const double BIOSPHERE_OFFSET=0;
+const double BIOSPHERE_SMOOTHNESS=1e-3;

--- a/common/materialContainer/MaterialContainer.h
+++ b/common/materialContainer/MaterialContainer.h
@@ -13,58 +13,79 @@
 #include <stdlib.h>
 #include <cstdlib>
 #include <type_traits>
+#include <map>
+#include <memory>
+#include "PerlinNoise.h"
+#include "block.h"
+
+
+
+extern const double GROUND_OFFSET;
+extern const double GROUND_SMOOTHNESS;
+extern const double BIOME_OFFSET;
+extern const double BIOME_SMOOTHNESS;
+extern const double BIOSPHERE_OFFSET;
+extern const double BIOSPHERE_SMOOTHNESS;
+
 
 class Material
 {
 private:
   std::string name;
+  BlockType type;
   double freq;
-
+  static std::map <std::string, std::shared_ptr<Material>> materialMap;
 public:
-  Material(std::string name, double freq) : name(name), freq(freq) {}
+  Material(std::string inName, BlockType inType, double inFreq) : name(inName), type(inType), freq(inFreq) {}
+  static std::shared_ptr<Material> makenew(std::string name, BlockType type, double freq);
   double getFreq() { return freq; }
   std::string getName() { return name; }
-  static Material Coal();
-  static Material Iron();
-  static Material Soil();
-  static Material Gravel();
-  static Material Sand();
-  static Material Diamond();
-  static Material Stone();
-  static Material Gold();
-  Material getMaterial();
+  std::shared_ptr<Material> getMaterial(int x, int y, int z);
+  BlockType getType(){ return type; }
+  void setType(BlockType BT){ type = BT; }
+  static std::shared_ptr<Material> getFromType(BlockType BT);
+  static std::shared_ptr<Material> Coal();
+  static std::shared_ptr<Material> Iron();
+  static std::shared_ptr<Material> Soil();
+  static std::shared_ptr<Material> Gravel();
+  static std::shared_ptr<Material> Sand();
+  static std::shared_ptr<Material> Diamond();
+  static std::shared_ptr<Material> Stone();
+  static std::shared_ptr<Material> Gold();
+  static std::shared_ptr<Material> Default();
 };
 
 template <class T> class MaterialContainer
 {
-protected:
+ protected:
+  double translate(int v){return((v+offset)* smoothness);}
+  static PerlinNoise noise;
   // temp PerlinNoise until intergration with project PerlinNoise
-  double PerlinNoise()
+  double PN(int x, int y, int z)
   {
-    return (static_cast<double>(rand()) / static_cast<double>(RAND_MAX));
+    static const int DEPTH=5;
+    return noise.turbulence3D(translate(x), translate(y), translate(z), DEPTH);
+    //return (static_cast<double>(rand()) / static_cast<double>(RAND_MAX));
   }
 
   std::string name;
-  std::vector<T> contents;
+  std::vector<std::shared_ptr<T>> contents;
   double freq; // likelihood of a material to show up on a scale of (0,1).
   double smoothness;
   double contentFreq;
+  double offset;
 
   // set the probability of a material to get created
   void setContentFreq()
   {
     contentFreq = 0;
-    for (T c : contents)
-      contentFreq += c.getFreq();
+    for (auto c : contents) contentFreq += c->getFreq();
   }
 
-public:
+ public:
   // MaterialContainer constructors and operator
-  MaterialContainer(std::string name,
-                    std::vector<T> contents,
-                    double freq,
-                    double smoothness)
-    : name(name), contents(contents), freq(freq), smoothness(smoothness)
+  MaterialContainer(std::string name, std::vector<std::shared_ptr<T>> contents, double freq, double smoothness, double offset)
+    :name(name), contents(contents), freq(freq), smoothness(smoothness), offset(offset)
   {
     setContentFreq();
   }
@@ -74,20 +95,20 @@ public:
     , freq(MC.freq)
     , smoothness(MC.smoothness)
     , contentFreq(MC.contentFreq)
-  {
-  }
+    , offset(MC.offset)
+    {}
   MaterialContainer& operator=(const MaterialContainer&) { return *this; }
 
   // decides what element to return based on noise input
-  T getElement(double noise)
+  std::shared_ptr<T> getElement(double noise)
   {
     double tot = 0.0;
     auto target = contentFreq * noise;
-    for (auto c : contents)
-    {
-      tot += c.getFreq();
-      if (tot >= target) return c;
-    }
+    for (uint i = 0;i< contents.size();++i)
+      {
+	    tot += contents[i]->getFreq();
+	    if (tot >= target) return contents[i];
+      }
     return contents[0];
   }
 
@@ -98,65 +119,72 @@ public:
   double getRarity() { return 1 - freq; };
 
   // Get the material type of a block at an (x,y,z) coordinate
-  virtual Material getMaterial()
+  virtual std::shared_ptr<Material> getMaterial(int x, int y, int z)
   {
-    double noise = PerlinNoise();
-    T content = getElement(noise);
-    return content.getMaterial();
+    double noise = PN(x, y, z);
+    std::shared_ptr<T> content = getElement(noise);
+    return content->getMaterial(x, y, z);
   }
 };
 
-class Ground : public MaterialContainer<Material>
+class GroundContainer : public MaterialContainer<Material>
 {
-public:
-  Material getMaterial();
-  static Ground sand();
-  static Ground oasis();
+ public:
+  std::shared_ptr<Material> getMaterial(int x, int y, int z);
+  static std::shared_ptr<GroundContainer> sand();
+  static std::shared_ptr<GroundContainer> oasis();
 
-  static Ground ironDeposits();
-  static Ground diamondDeposits();
-  static Ground goldDeposits();
-  static Ground noOre();
+  static std::shared_ptr<GroundContainer> ironDeposits();
+  static std::shared_ptr<GroundContainer> diamondDeposits();
+  static std::shared_ptr<GroundContainer> goldDeposits();
+  static std::shared_ptr<GroundContainer> noOre();
 
-  static Ground soil();
-  static Ground rockySoil();
-  static Ground sandySoil();
-  Ground(std::string name,
-         std::vector<Material> contents,
+  static std::shared_ptr<GroundContainer> soil();
+  static std::shared_ptr<GroundContainer> rockySoil();
+  static std::shared_ptr<GroundContainer> sandySoil();
+  GroundContainer(std::string name,
+         std::vector<std::shared_ptr<Material>> contents,
          double freq,
          double smoothness)
-    : MaterialContainer(name, contents, freq, smoothness)
-  {
-  }
+    : MaterialContainer(name, contents, freq, GROUND_SMOOTHNESS, GROUND_OFFSET)
+    {
+      (void) smoothness;
+    }
 };
 
-class Biome : public MaterialContainer<Ground>
+class Biome : public MaterialContainer<GroundContainer>
 {
-public:
-  static Biome sandyDesert();
-  static Biome mountain();
-  static Biome fertileFarmland();
+ public:
+  static std::shared_ptr<Biome> sandyDesert();
+  static std::shared_ptr<Biome> mountain();
+  static std::shared_ptr<Biome> fertileFarmland();
   Biome(std::string name,
-        std::vector<Ground> contents,
+        std::vector<std::shared_ptr<GroundContainer>> contents,
         double freq,
         double smoothness)
-    : MaterialContainer(name, contents, freq, smoothness)
-  {
-  }
+    : MaterialContainer(name, contents, freq, BIOME_SMOOTHNESS, BIOME_OFFSET)
+    {
+      (void) smoothness;
+    }
 };
 
 class Biosphere : public MaterialContainer<Biome>
 {
-public:
+ public:
   Biosphere(std::string name,
-            std::vector<Biome> contents,
+            std::vector<std::shared_ptr<Biome>> contents,
             double freq,
             double smoothness)
-    : MaterialContainer(name, contents, freq, smoothness)
-  {
-  }
-
+    : MaterialContainer(name, contents, freq, BIOSPHERE_SMOOTHNESS, BIOSPHERE_OFFSET)
+    {
+      (void) smoothness;
+    }
+   BlockType GetBlockType(int x, int y, int z){
+     return getMaterial(x,y,z)-> getType();
+   }
   static Biosphere getBasicBiosphere();
 };
+
+
 
 #endif

--- a/common/voxel/block.h
+++ b/common/voxel/block.h
@@ -16,7 +16,12 @@ enum BlockType
   Stone,
   Grass,
   Brick,
-  Party
+  Party,
+  Coal,
+  Iron,
+  Gravel,
+  Diamond,
+  Gold
 };
 
 class Block
@@ -34,8 +39,6 @@ public:
 
 private:
   BlockType type;
-
-  //		BlockType mBlockType;
 };
 
 #endif

--- a/common/worldFactory.cpp
+++ b/common/worldFactory.cpp
@@ -1,9 +1,12 @@
 #include "worldFactory.h"
 
-WorldFactory::WorldFactory(int tempMinElevation, int tempMaxElevation)
+WorldFactory::WorldFactory(int minElevation, int maxElevation, int noiseDepth)
 {
-  minElevation = tempMinElevation;
-  maxElevation = tempMaxElevation;
+  this->minElevation = minElevation;
+  this->maxElevation = maxElevation;
+  this->noise = PerlinNoise();
+  this->noiseDepth = noiseDepth;
+  //this->biosphere = Biosphere::getBasicBiosphere();
 }
 
 int WorldFactory::getMinElevation() const
@@ -16,8 +19,14 @@ int WorldFactory::getMaxElevation() const
   return maxElevation;
 }
 
-int WorldFactory::elevation(int x, int y, PerlinNoise noise, int noiseDepth)
+int WorldFactory::elevation(Vector3 v)
 {
-  double weight = noise.turbulence2D(x, y, noiseDepth);
+  double weight = noise.turbulence2D(v.x, v.y, noiseDepth);
   return minElevation * (1 - weight) + maxElevation * weight;
+}
+
+BlockType WorldFactory::computeBlockType(Vector3 globalXYZ){
+   if(globalXYZ.z <= elevation(globalXYZ))
+       return BlockType::Inactive;
+   return biosphere.GetBlockType(globalXYZ.x,globalXYZ.y,globalXYZ.z);
 }

--- a/common/worldFactory.h
+++ b/common/worldFactory.h
@@ -2,17 +2,25 @@
 #define WorldFactory_h
 
 #include "noise/PerlinNoise.h"
+#include "voxel/block.h"
+#include "vector3.h"
+#include "MaterialContainer.h"
 
 // thread unsafe
 class WorldFactory
 {
 public:
-  WorldFactory(int, int);
+  WorldFactory(int, int, int);
   int getMinElevation() const;
   int getMaxElevation() const;
-  int elevation(int x, int y, PerlinNoise noise, int noiseDepth);
+  int elevation(Vector3 v);
+  BlockType computeBlockType(Vector3 globalXYZ);
 
 private:
+  Biosphere biosphere = Biosphere::getBasicBiosphere ();
   int minElevation, maxElevation;
+  PerlinNoise noise;
+  int noiseDepth;
 };
+
 #endif


### PR DESCRIPTION
and smooth blocktypes that depend on a global xyz

For this to actually work the chunck manager needs to actually use
the "block" class and to construct a "block" by passing it an xyz,
then the block or chunck or anything can ask the worldFactory for
a type.