### PR TITLE
Added Compass Class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,7 @@ set(common_srcs
   common/interfaces/IVertexContainer.cpp
 
   common/util/vector3.cpp
+  common/util/Compass.cpp
 
   common/voxel/block.cpp
   common/voxel/chunk.cpp

--- a/common/util/Compass.cpp
+++ b/common/util/Compass.cpp
@@ -4,75 +4,78 @@
 #include "tbb/blocked_range.h"
 #include "tbb/concurrent_queue.h"
 #include "../world.h"
-
-#include <array>
+#include "chunkmanager.h"
 #include <iostream>
-#include <typeinfo>
 
-Compass::Compass(World input, glm::vec3 pos)
+int modx(int s)
 {
-  world = input;
+  return (s>0?s%ChunkManager::BOUNDX :(s+ChunkManager::BOUNDX)%ChunkManager::BOUNDX);
+};
+
+int mody(int s)
+{
+  return (s>0?s%ChunkManager::BOUNDY :(s+ChunkManager::BOUNDY)%ChunkManager::BOUNDY);
+};
+
+int modz(int s)
+{
+  return s;
+};
+
+Compass::Compass(World inWorld, ChunkManager inChunk, glm::vec3 pos)
+{
+  world = inWorld;
+  chunk = inChunk;
   currentPos = pos;
 };
 
 struct CheckType
 {
-  //const Block* input;
   std::vector<std::shared_ptr<Block> > blocks;
-  glm::vec3 position;
   BlockType type;
-  bool* output;
+  bool* found;
+  ChunkManager* chunk;
+  glm::vec3* distance;
   void operator()( const tbb::blocked_range<int>& range ) const
   {
-        for (int i=range.begin(); i!=range.end(); ++i)
+    for (auto i=range.begin(); i!=range.end(); ++i)
       {
-	    if (blocks[i]->position == position)
-	      {
-		if (blocks[i]->type == type)
-		  output[i] = true;
-		else
-		  output[i] = false;
+	if (type == chunk->get(blocks[i]->position.x, blocks[i]->position.y, blocks[i]->position.z))
+	  {
+	    (*found) = true;
+	    (*distance) = blocks[i]->position;
 	  }
       }
   }
 };
 
 
-int Compass::find(BlockType type)
+glm::vec3 Compass::find(BlockType type)
 {  
   auto blocks = world.blocks;
   auto worldSize = blocks.size();
   auto found = false;
   auto distance = 1;
-  bool boolArray[worldSize];
+  glm::vec3 typeDistance;
 
-  while (!found)
+  while (distance <= static_cast<int>(worldSize)/2)
     {
-      auto q = getQueue(currentPos, distance);
-      auto qSize = q.unsafe_size();
-      glm::vec3 e;      
+      auto q = getQueue(currentPos, distance, worldSize);
+      CheckType check;
+      check.chunk =& chunk;
+      check.blocks = blocks;
+      check.type = type;
+      check.found = &found;
+      check.distance = &typeDistance;
 
-      while (q.try_pop(e))
-	{
-	  CheckType check;
-	  check.blocks = blocks;
-	  check.position = e;
-	  check.type = type;
-	  check.output = boolArray;
+      tbb::parallel_for( tbb::blocked_range<int>(0, q.unsafe_size()), check);
+      if (found)
+	return typeDistance;
 
-	  tbb::parallel_for( tbb::blocked_range<int>( 1, worldSize), check);
-
-	  for (unsigned int i=0; i< worldSize; ++i)
-	    if (boolArray[i] == true)
-	      return distance;
-	}
-
-      if (worldSize == qSize)
-	return -1;
-      distance++;
+       ++distance;
     }
-  
-  return -1;
+
+  return glm::vec3(0,0,0);
 };
 
 struct populatej {
@@ -80,6 +83,7 @@ struct populatej {
   glm::vec3*  start;
   int distance;
   int i;
+  int worldSize;
   void operator()( tbb::blocked_range<int>& range ) const {
     for( int j=range.begin(); j!=range.end(); ++j ){
       int k=i>0?distance-j:distance+j;
@@ -93,6 +97,7 @@ struct populateQueue {
   tbb::concurrent_queue<glm::vec3>* queue;
   glm::vec3* start;
   int distance;
+  int worldSize;
   void operator()( tbb::blocked_range<int>& range ) const {
     for( int i=range.begin(); i!=range.end(); ++i ){
       populatej jloop;
@@ -101,17 +106,18 @@ struct populateQueue {
       jloop.queue=queue;
       jloop.start=start;
       jloop.i=i;
+      jloop.worldSize=worldSize;
       tbb::parallel_for( tbb::blocked_range<int>(-jdistance,jdistance),jloop);
     }
   }
 };
 
-
-tbb::concurrent_queue<glm::vec3> Compass::getQueue( glm::vec3&  start,int dis ) {
+tbb::concurrent_queue<glm::vec3> Compass::getQueue( glm::vec3&  start,int dis , int worldSize) {
   tbb::concurrent_queue<glm::vec3> queue;
   populateQueue pq;
   pq.queue=&queue;
   pq.distance=dis;
+  pq.worldSize=worldSize;
   pq.start=&start;
   tbb::parallel_for( tbb::blocked_range<int>( -dis, +dis ), pq );
   return queue;

--- a/common/util/Compass.cpp
+++ b/common/util/Compass.cpp
@@ -1,0 +1,119 @@
+#include "Compass.h"
+#include "tbb/tbb.h"
+#include "tbb/parallel_for.h"
+#include "tbb/blocked_range.h"
+#include "tbb/concurrent_queue.h"
+#include "../world.h"
+
+#include <array>
+#include <iostream>
+#include <typeinfo>
+
+Compass::Compass(World input, glm::vec3 pos)
+{
+  world = input;
+  currentPos = pos;
+};
+
+struct CheckType
+{
+  //const Block* input;
+  std::vector<std::shared_ptr<Block> > blocks;
+  glm::vec3 position;
+  BlockType type;
+  bool* output;
+  void operator()( const tbb::blocked_range<int>& range ) const
+  {
+        for (int i=range.begin(); i!=range.end(); ++i)
+      {
+	    if (blocks[i]->position == position)
+	      {
+		if (blocks[i]->type == type)
+		  output[i] = true;
+		else
+		  output[i] = false;
+	  }
+      }
+  }
+};
+
+
+int Compass::find(BlockType type)
+{  
+  auto blocks = world.blocks;
+  auto worldSize = blocks.size();
+  auto found = false;
+  auto distance = 1;
+  bool boolArray[worldSize];
+
+  while (!found)
+    {
+      auto q = getQueue(currentPos, distance);
+      auto qSize = q.unsafe_size();
+      glm::vec3 e;      
+
+      while (q.try_pop(e))
+	{
+	  CheckType check;
+	  check.blocks = blocks;
+	  check.position = e;
+	  check.type = type;
+	  check.output = boolArray;
+
+	  tbb::parallel_for( tbb::blocked_range<int>( 1, worldSize), check);
+
+	  for (unsigned int i=0; i< worldSize; ++i)
+	    if (boolArray[i] == true)
+	      return distance;
+	}
+
+      if (worldSize == qSize)
+	return -1;
+      distance++;
+    }
+  
+  return -1;
+};
+
+struct populatej {
+  tbb::concurrent_queue<glm::vec3>* queue;
+  glm::vec3*  start;
+  int distance;
+  int i;
+  void operator()( tbb::blocked_range<int>& range ) const {
+    for( int j=range.begin(); j!=range.end(); ++j ){
+      int k=i>0?distance-j:distance+j;
+      queue->push(glm::vec3(start->x+i,start->y+j,start->z+k));
+      if(k!=0)queue->push(glm::vec3(start->x+i,start->y+j,start->z-k));
+    }
+  }
+};
+
+struct populateQueue {
+  tbb::concurrent_queue<glm::vec3>* queue;
+  glm::vec3* start;
+  int distance;
+  void operator()( tbb::blocked_range<int>& range ) const {
+    for( int i=range.begin(); i!=range.end(); ++i ){
+      populatej jloop;
+      int jdistance=i>0?distance-i:distance+i;
+      jloop.distance=jdistance;
+      jloop.queue=queue;
+      jloop.start=start;
+      jloop.i=i;
+      tbb::parallel_for( tbb::blocked_range<int>(-jdistance,jdistance),jloop);
+    }
+  }
+};
+
+
+tbb::concurrent_queue<glm::vec3> Compass::getQueue( glm::vec3&  start,int dis ) {
+  tbb::concurrent_queue<glm::vec3> queue;
+  populateQueue pq;
+  pq.queue=&queue;
+  pq.distance=dis;
+  pq.start=&start;
+  tbb::parallel_for( tbb::blocked_range<int>( -dis, +dis ), pq );
+  return queue;
+}
+

--- a/common/util/Compass.h
+++ b/common/util/Compass.h
@@ -4,8 +4,7 @@
 #include "tbb/blocked_range.h"
 #include "tbb/concurrent_queue.h"
 #include "../world.h"
-#include "vector3.cpp"
-
+#include "../voxel/chunkmanager.cpp"
 
 class Compass
 {
@@ -13,12 +12,11 @@ class Compass
   glm::vec3 currentPos;
   int n;
   World world;
+  ChunkManager chunk;
 
-  Compass(World, glm::vec3);
-  tbb::concurrent_queue<glm::vec3> getQueue( glm::vec3&,int);
-  int find(BlockType);
-
-  
+  Compass(World, ChunkManager, glm::vec3);
+  tbb::concurrent_queue<glm::vec3> getQueue( glm::vec3&,int, int);
+  glm::vec3 find(BlockType);
 
 };
 #endif

--- a/common/util/Compass.h
+++ b/common/util/Compass.h
@@ -1,0 +1,24 @@
+#ifndef COMPASS_H
+#define COMPASS_H
+#include "tbb/parallel_for.h"
+#include "tbb/blocked_range.h"
+#include "tbb/concurrent_queue.h"
+#include "../world.h"
+#include "vector3.cpp"
+
+
+class Compass
+{
+ public:
+  glm::vec3 currentPos;
+  int n;
+  World world;
+
+  Compass(World, glm::vec3);
+  tbb::concurrent_queue<glm::vec3> getQueue( glm::vec3&,int);
+  int find(BlockType);
+
+  
+
+};
+#endif


### PR DESCRIPTION
David and I (Soren) have added a Compass class to the project. It has not been added to the GUI but when you implement it will give the distance from your current position to the closest material of your choosing. Unlike our original proposal the algorithm does not calculate the shortest walking distance. 

We check the area around a person for a certain material, starting at distance one. If that area does not contain the material then increase the distance of our search area by one. We continue this until we have found the material or have searched the entire world and failed to find the material. We have found three places in our algorithm where we have obtained speedup by using tbb::parallel_for. We populate the queue of points to check in parallel. After which we check each point is the material we want in parallel. We then have to check the Boolean array to see if the material was found at the current distance. This gives us O(n \* q) where n is the number of blocks in the world and q is the size of the queue. Having to access each element of the concurrent_queue one at a time slowed down the function more then we would have liked.
